### PR TITLE
MCES-distance split: identify val/test molecules far from the training set

### DIFF
--- a/config_runners/run_mces_split.sh
+++ b/config_runners/run_mces_split.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# One-shot launcher for the MCES-distance split on MetaCentrum (plzen1).
+# Stage 1 (prefilter, blocking) -> stage 2 (compute array). Stage 3 (report) is a
+# quick final step printed to run once the array finishes. Override any default
+# via environment, e.g. WORKDIR=... CEILING=10 bash config_runners/run_mces_split.sh
+set -euo pipefail
+
+PLZEN_HOME="${PLZEN_HOME:-/storage/plzen1/home/jozefov_147}"
+export REPO_DIR="${REPO_DIR:-$PLZEN_HOME/projects/SpecTUS}"
+export ENV_PREFIX="${ENV_PREFIX:-$PLZEN_HOME/.conda/envs/spectus_mces}"
+export WORKDIR="${WORKDIR:-$PLZEN_HOME/projects/spectus_mces_runs}"   # holds batches (tens of GB) + results
+export CEILING="${CEILING:-10}"
+export BATCH_SIZE="${BATCH_SIZE:-10000000}"
+RUN="$REPO_DIR/config_runners"
+mkdir -p "$WORKDIR"
+
+echo "[1/3] prefilter (blocks until the compute-node job finishes)..."
+qsub -W block=true -v REPO_DIR,ENV_PREFIX,WORKDIR,CEILING,BATCH_SIZE "$RUN/run_mces_split_prefilter.sh"
+N=$(python3 -c "import json; print(json.load(open('$WORKDIR/manifest.json'))['n_batches'])")
+echo "  -> $N batches"
+
+echo "[2/3] compute array 0-$((N - 1)) (idempotent: re-submit to recompute only missing batches)..."
+AID=$(qsub -J "0-$((N - 1))" -v REPO_DIR,ENV_PREFIX,WORKDIR,CEILING "$RUN/run_mces_split_compute.sh")
+echo "  -> array job $AID"
+
+cat <<EOF
+[3/3] Once the array finishes (watch: qstat -tu \$(whoami)), run the report:
+  qsub -v REPO_DIR=$REPO_DIR,ENV_PREFIX=$ENV_PREFIX,WORKDIR=$WORKDIR $RUN/run_mces_split_report.sh
+Results -> $WORKDIR/results/ (far_{valid,test}_t{6..10}_clean.smi, incomputable.smi, near_pairs.parquet, nn_distances.parquet)
+EOF

--- a/config_runners/run_mces_split_compute.sh
+++ b/config_runners/run_mces_split_compute.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#PBS -N mces_compute
+#PBS -l select=1:ncpus=32:mem=16gb:scratch_local=20gb
+#PBS -l walltime=6:00:00
+# MCES-distance split, stage 2 (ARRAY): one HDF5 batch per array index, computed
+# with myopic-MCES using Fleming's recommended settings (dynamic bound, CPLEX/CBC
+# single-threaded, silent). Submit with: qsub -J 0-<N-1> -v REPO_DIR,ENV_PREFIX,WORKDIR[,CEILING]
+# NOTE: an explicit --solver is required for --solver_no_msg to take effect
+# (the 'default' solver path ignores solver options and floods stdout).
+set -euo pipefail
+test "$(whoami)" = "jozefov_147" || { echo "Refuse: wrong account"; exit 1; }
+: "${REPO_DIR:?}"; : "${ENV_PREFIX:?}"; : "${WORKDIR:?}"
+CEILING="${CEILING:-10}"
+SOLVER="${SOLVER:-PULP_CBC_CMD}"   # set to CPLEX_CMD if a CPLEX module is loaded
+TIME_LIMIT="${TIME_LIMIT:-30}"    # per-pair ILP-solver cap (s)
+WALL_CAP="${WALL_CAP:-45}"        # hard per-pair wall cap (s); bounds the matching-bound tail
+NJOBS="${PBS_NCPUS:-$(nproc)}"
+
+BATCH="$WORKDIR/batches/batch${PBS_ARRAY_INDEX}.hdf5"
+# Idempotent: skip batches already computed, so the array can be re-run safely
+# (durable per-batch checkpointing — a completed batch carries its 'mces' dataset).
+if "$ENV_PREFIX/bin/python" -c "import h5py,sys; sys.exit(0 if 'mces' in h5py.File('$BATCH','r') else 1)" 2>/dev/null; then
+  echo "batch ${PBS_ARRAY_INDEX} already computed — skipping"; exit 0
+fi
+mkdir -p "$SCRATCHDIR/tmp"; export TMPDIR="$SCRATCHDIR/tmp"
+module add mambaforge; mamba activate "$ENV_PREFIX"
+cd "$REPO_DIR"
+
+cp "$BATCH" "$SCRATCHDIR/" || exit 2
+LOCAL="$SCRATCHDIR/$(basename "$BATCH")"
+# Computes via myopic-MCES (dynamic bound) and writes distances back into LOCAL.
+python -m mces_split.compute \
+  --batch "$LOCAL" --threshold "$CEILING" --solver "$SOLVER" \
+  --solver-time-limit "$TIME_LIMIT" --wall-cap "$WALL_CAP" --num-jobs "$NJOBS" \
+  > "$SCRATCHDIR/compute_${PBS_ARRAY_INDEX}.log" 2>&1 || { tail -50 "$SCRATCHDIR/compute_${PBS_ARRAY_INDEX}.log"; exit 3; }
+cp "$LOCAL" "$BATCH" || exit 4   # batch now carries the computed distances
+clean_scratch

--- a/config_runners/run_mces_split_prefilter.sh
+++ b/config_runners/run_mces_split_prefilter.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#PBS -N mces_prefilter
+#PBS -l select=1:ncpus=4:mem=16gb:scratch_local=10gb
+#PBS -l walltime=4:00:00
+# MCES-distance split, stage 1: rigorous two-bound pre-filter -> candidate-pair
+# HDF5 batches. Pass via `qsub -v`: REPO_DIR, ENV_PREFIX, WORKDIR [, CEILING, BATCH_SIZE].
+set -euo pipefail
+test "$(whoami)" = "jozefov_147" || { echo "Refuse: wrong account"; exit 1; }
+: "${REPO_DIR:?}"; : "${ENV_PREFIX:?}"; : "${WORKDIR:?}"
+CEILING="${CEILING:-10}"; BATCH_SIZE="${BATCH_SIZE:-10000000}"
+
+mkdir -p "$WORKDIR" "$SCRATCHDIR/tmp"; export TMPDIR="$SCRATCHDIR/tmp"
+module add mambaforge; mamba activate "$ENV_PREFIX"
+cd "$REPO_DIR"
+
+# Batches are written straight to persistent WORKDIR (one sequential write).
+python -m mces_split.prefilter \
+  --data-dir "$REPO_DIR/data/nist" --out-dir "$WORKDIR" \
+  --ceiling "$CEILING" --batch-size "$BATCH_SIZE"
+clean_scratch

--- a/config_runners/run_mces_split_report.sh
+++ b/config_runners/run_mces_split_report.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#PBS -N mces_report
+#PBS -l select=1:ncpus=2:mem=32gb:scratch_local=10gb
+#PBS -l walltime=2:00:00
+# MCES-distance split, stage 3: build near_pairs.parquet and report the far/close
+# split at the requested thresholds (default 6 7 8 9 10), excluding molecules with
+# any incomputable pair so the far set is certain at every threshold. Pass via
+# `qsub -v`: REPO_DIR, ENV_PREFIX, WORKDIR [, RESULTS, THRESHOLDS, EXCLUDE_INCOMPUTABLE].
+set -euo pipefail
+test "$(whoami)" = "jozefov_147" || { echo "Refuse: wrong account"; exit 1; }
+: "${REPO_DIR:?}"; : "${ENV_PREFIX:?}"; : "${WORKDIR:?}"
+RESULTS="${RESULTS:-$WORKDIR/results}"
+THRESHOLDS="${THRESHOLDS:-6 7 8 9 10}"
+EXCLUDE="${EXCLUDE_INCOMPUTABLE:-1}"
+
+module add mambaforge; mamba activate "$ENV_PREFIX"
+cd "$REPO_DIR"
+FLAGS=""; [ "$EXCLUDE" = "1" ] && FLAGS="--exclude-incomputable"
+python -m mces_split.split --out-dir "$WORKDIR" --results-dir "$RESULTS" --thresholds $THRESHOLDS $FLAGS

--- a/config_runners/run_mces_split_setup.sh
+++ b/config_runners/run_mces_split_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#PBS -N spectus_mces_env
+#PBS -l select=1:ncpus=4:mem=16gb:scratch_local=20gb
+#PBS -l walltime=2:00:00
+# Create the dedicated `spectus_mces` env and install SpecTUS with the [mces]
+# extra (no torch is pulled — setup.py has no core deps). Run installs on a
+# compute node, not the frontend. Override paths via `qsub -v REPO_DIR,ENV_PREFIX`.
+set -euo pipefail
+test "$(whoami)" = "jozefov_147" || { echo "Refuse: wrong account"; exit 1; }
+PLZEN_HOME=/storage/plzen1/home/jozefov_147
+REPO_DIR="${REPO_DIR:-$PLZEN_HOME/projects/SpecTUS}"
+ENV_PREFIX="${ENV_PREFIX:-$PLZEN_HOME/.conda/envs/spectus_mces}"
+
+mkdir -p "$SCRATCHDIR/tmp"; export TMPDIR="$SCRATCHDIR/tmp"
+module add mambaforge
+if [ ! -d "$ENV_PREFIX" ]; then
+  mamba create --prefix "$ENV_PREFIX" python=3.11 -y
+fi
+mamba run -p "$ENV_PREFIX" python -m pip install --upgrade pip setuptools wheel
+mamba run -p "$ENV_PREFIX" python -m pip install -e "${REPO_DIR}[mces]"
+mamba run -p "$ENV_PREFIX" python -c \
+  "import mces_split, myopic_mces, rdkit, scipy, h5py, pandas, pyarrow; print('env OK')"
+clean_scratch

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,24 @@ setup(
     version="0.1",
     packages=find_packages(where="spectus"),
     package_dir={"": "spectus"},
+    # Optional dev extra for the MCES-distance split analysis (spectus/mces_split).
+    # Kept out of the core deps so regular SpecTUS users don't pull the ILP stack:
+    #   pip install -e ".[mces]"
+    # Pinned to the versions that produced the published result (reproducibility).
+    extras_require={
+        "mces": [
+            "myopic-mces==1.0.1",
+            "rdkit==2026.3.2",
+            "numpy==2.4.6",
+            "scipy==1.17.1",
+            "pandas==3.0.3",
+            "pyarrow==24.0.0",
+            "h5py==3.16.0",
+            "joblib==1.5.3",
+            "pulp==3.3.2",
+            "networkx==3.6.1",
+            "tqdm",
+        ],
+        "test": ["pytest"],
+    },
 )

--- a/spectus/mces_split/README.md
+++ b/spectus/mces_split/README.md
@@ -1,0 +1,82 @@
+# MCES-distance split analysis
+
+Identifies validation/test molecules whose **nearest training-set neighbour is at
+MCES distance ≥ T** (default 10), showing the NIST train/val/test split (built on
+InChIKey14) contains structurally novel molecules — not just near-duplicates of
+training compounds. Distance 10 matches the single-linkage criterion of the
+MCES-based split in MassSpecGym; the metric is the myopic maximum-common-edge-subgraph
+edit distance from [`myopic-mces`](https://github.com/AlBi-HHU/myopic-mces).
+
+## Result (NIST, ceiling 10)
+
+Molecules ≥ T MCES edits from *every* training molecule, over the clean universe
+(molecules where every distance is computable):
+
+| T | far_valid | far_test |
+|---|-----------|----------|
+| 6 | 2,164 (8.96%) | 2,170 (8.98%) |
+| 8 | 1,005 (4.16%) | 1,002 (4.15%) |
+| 10 | 446 (1.85%) | 469 (1.94%) |
+
+357 molecules (0.7%) were excluded as MCES-intractable (very large structures
+where the ILP cannot terminate); 0 false positives among all computable pairs.
+
+## Why it is fast *and* rigorous
+
+For ~48k query × ~195k train molecules (~9.5 B pairs), almost all are far. The
+candidates are pruned with **two vectorised, rigorous MCES lower bounds**
+(`bounds.py`):
+
+* **`Filter1Bound`** — the degree bound (`myopic_mces.filter1`) as a half-cityblock
+  of zero-padded sorted per-element weighted-degree sequences.
+* **`BondTypeBound`** — edges only map between equal element-pair types, so the
+  per-bond-type total-weight cityblock is a valid lower bound.
+
+`CompositeBound` takes their max (still a true lower bound), so a discarded pair
+is *provably* ≥ ceiling — no false "far". Only the ~9% of survivors reach the ILP.
+
+## Architecture (`spectus/mces_split/`)
+
+| Module | Class | Role |
+|--------|-------|------|
+| `bounds.py` | `RigorousBound` → `Filter1Bound`, `BondTypeBound`, `CompositeBound` | rigorous vectorised lower bounds |
+| `dataset.py` | `Folds` | load/canonicalise (SpecTUS-consistent)/dedupe the `.smi` folds |
+| `prefilter.py` | `PreFilter` | bound screen → candidate-pair HDF5 batches + manifest |
+| `compute.py` | `BatchComputer` | myopic-MCES on a batch (solver + wall caps) |
+| `split.py` | `SplitReport` | near-pairs → far/close split at any threshold, ± incomputable exclusion |
+| `io.py` | — | shared HDF5 read/write, error-pair scan, per-pair `time_limit` |
+
+## Workflow
+
+```
+prefilter   data/nist/{train,valid,test}.smi ─▶ batches/*.hdf5 + queries.parquet + manifest.json
+compute     batches/*.hdf5 (one per array task) ─▶ same files, now with `mces` distances
+report      batches + queries.parquet ─▶ near_pairs.parquet, nn_distances.parquet,
+                                         incomputable.smi, far_{valid,test}_t{T}_clean.smi
+```
+
+### Local (small sample)
+
+```bash
+pip install -e ".[mces]"
+python -m mces_split.prefilter --out-dir /tmp/run --limit-queries 200 --limit-train 10000
+for b in /tmp/run/batches/batch*.hdf5; do python -m mces_split.compute --batch "$b"; done
+python -m mces_split.split --out-dir /tmp/run --results-dir /tmp/run/results --thresholds 6 8 10 --exclude-incomputable
+```
+
+### Full run on MetaCentrum (plzen1)
+
+```bash
+bash config_runners/run_mces_split.sh   # prefilter ▸ compute array; then run the report it prints
+```
+
+Tests: `pytest tests/test_mces_split.py` runs the whole pipeline on a tiny fixture
+and checks the far classification against a brute-force minimum.
+
+## Notes
+
+* The compute array is **idempotent** (a batch carrying `mces` is skipped), so a
+  re-submit resumes after any walltime kill — durable per-batch checkpoints.
+* Each pair is bounded by a solver time limit *and* a hard wall cap (the matching
+  bound is pure-Python and the solver limit doesn't cover it).
+* Dependencies are pinned in `setup.py[mces]` to the versions that produced the result.

--- a/spectus/mces_split/__init__.py
+++ b/spectus/mces_split/__init__.py
@@ -1,0 +1,24 @@
+"""MCES-distance split analysis for the NIST SMILES folds.
+
+Identifies validation/test molecules whose nearest training-set neighbour is at
+MCES distance >= a threshold (default 10), showing the train/val/test split
+contains structurally novel molecules. Three stages: ``PreFilter`` (rigorous
+bound screen -> candidate batches), ``BatchComputer`` (myopic-MCES), ``SplitReport``
+(far/close split at any threshold). See ``README.md``.
+"""
+from mces_split.bounds import BondTypeBound, CompositeBound, Filter1Bound, RigorousBound
+from mces_split.compute import BatchComputer
+from mces_split.dataset import Folds
+from mces_split.prefilter import PreFilter
+from mces_split.split import SplitReport
+
+__all__ = [
+    "Folds",
+    "RigorousBound",
+    "Filter1Bound",
+    "BondTypeBound",
+    "CompositeBound",
+    "PreFilter",
+    "BatchComputer",
+    "SplitReport",
+]

--- a/spectus/mces_split/bounds.py
+++ b/spectus/mces_split/bounds.py
@@ -1,0 +1,128 @@
+"""Rigorous, vectorised lower bounds on the myopic-MCES distance.
+
+MCES runs on the heavy-atom graph with bond-order edge weights (single 1, double
+2, triple 3, aromatic 1.5; see ``myopic_mces.graph.construct_graph``). Each bound
+maps a molecule to a feature vector such that
+
+    bound(a, b) = scale * cityblock(feature(a), feature(b))  <=  MCES(a, b)
+
+so a single ``cdist`` screens a whole reference set, and we only run the
+expensive ILP on pairs that *could* be below the threshold. Two independent
+bounds are combined (``CompositeBound``) by taking their max — still a valid
+lower bound, but much tighter than either alone.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+from rdkit import Chem
+from scipy.spatial.distance import cdist
+
+
+class RigorousBound(ABC):
+    """A vectorisable lower bound: ``scale * cityblock(feature(a), feature(b))``."""
+
+    scale: float
+
+    @abstractmethod
+    def feature_matrix(self, mols: list[Chem.Mol]) -> np.ndarray:
+        """Build the [n_molecules, n_features] feature matrix for these molecules."""
+
+    def cityblock_cutoff(self, ceiling: float) -> float:
+        """Cityblock distance below which the bound is < ceiling (so a pair may be too)."""
+        return ceiling / self.scale
+
+
+class Filter1Bound(RigorousBound):
+    """Degree bound (``myopic_mces.filter_MCES.filter1``), in vectorised form.
+
+    For each element, the atoms' weighted degrees (sum of incident bond orders)
+    are sorted descending and zero-padded to a global length; the half-cityblock
+    of the concatenation equals filter1.
+    """
+
+    scale = 0.5
+
+    def feature_matrix(self, mols: list[Chem.Mol]) -> np.ndarray:
+        seqs = [self._element_degree_sequences(m) for m in mols]
+        layout: dict[str, int] = {}
+        for s in seqs:
+            for element, degrees in s.items():
+                layout[element] = max(layout.get(element, 0), len(degrees))
+        offsets, total = {}, 0
+        for element in sorted(layout):
+            offsets[element] = total
+            total += layout[element]
+        mat = np.zeros((len(mols), total), dtype=np.float32)
+        for row, s in enumerate(seqs):
+            for element, degrees in s.items():
+                off = offsets[element]
+                mat[row, off : off + len(degrees)] = degrees
+        return mat
+
+    @staticmethod
+    def _element_degree_sequences(mol: Chem.Mol) -> dict[str, list[float]]:
+        seqs: dict[str, list[float]] = {}
+        for atom in mol.GetAtoms():
+            degree = sum(b.GetBondTypeAsDouble() for b in atom.GetBonds())
+            seqs.setdefault(atom.GetSymbol(), []).append(degree)
+        for symbol in seqs:
+            seqs[symbol].sort(reverse=True)
+        return seqs
+
+
+class BondTypeBound(RigorousBound):
+    """Bond-type bound: edges only map between equal element-pair types, so the
+    per-bond-type total-weight cityblock is a valid lower bound (each bond counted
+    once, hence scale 1)."""
+
+    scale = 1.0
+
+    def feature_matrix(self, mols: list[Chem.Mol]) -> np.ndarray:
+        weights = [self._bondtype_weights(m) for m in mols]
+        types = sorted({t for w in weights for t in w})
+        index = {t: i for i, t in enumerate(types)}
+        mat = np.zeros((len(mols), len(types)), dtype=np.float32)
+        for row, w in enumerate(weights):
+            for t, value in w.items():
+                mat[row, index[t]] = value
+        return mat
+
+    @staticmethod
+    def _bondtype_weights(mol: Chem.Mol) -> dict[tuple[str, str], float]:
+        w: dict[tuple[str, str], float] = {}
+        for bond in mol.GetBonds():
+            t = tuple(sorted((bond.GetBeginAtom().GetSymbol(), bond.GetEndAtom().GetSymbol())))
+            w[t] = w.get(t, 0.0) + bond.GetBondTypeAsDouble()
+        return w
+
+
+class CompositeBound:
+    """Several rigorous bounds combined by their max — a pair survives only if it
+    is below the ceiling under *every* bound."""
+
+    def __init__(self, bounds: list[RigorousBound]):
+        self.bounds = bounds
+
+    def feature_matrices(self, mols: list[Chem.Mol]) -> list[np.ndarray]:
+        """One feature matrix per bound (build over all molecules to share the layout)."""
+        return [b.feature_matrix(mols) for b in self.bounds]
+
+    def candidate_mask(self, query_feats: list[np.ndarray], train_feats: list[np.ndarray],
+                       ceiling: float) -> np.ndarray:
+        """
+        Boolean [n_query, n_train] mask of pairs that could be below the ceiling.
+
+        Args:
+            query_feats (list[np.ndarray]): per-bound query feature blocks.
+            train_feats (list[np.ndarray]): per-bound train feature blocks.
+            ceiling (float): MCES threshold.
+        Returns:
+            np.ndarray: True where every bound is below the ceiling.
+        """
+        mask: np.ndarray | None = None
+        for bound, qf, tf in zip(self.bounds, query_feats, train_feats):
+            below = cdist(qf, tf, metric="cityblock") < bound.cityblock_cutoff(ceiling)
+            mask = below if mask is None else (mask & below)
+        return mask

--- a/spectus/mces_split/compute.py
+++ b/spectus/mces_split/compute.py
@@ -1,0 +1,94 @@
+"""Stage 2: compute myopic-MCES for one HDF5 batch.
+
+Thin wrapper around ``myopic_mces.MCES`` (Fleming's algorithm) adding a per-pair
+solver time limit and a hard wall-clock cap -- a tiny fraction of pairs otherwise
+dominate the runtime, and some of that is in the (pure-Python) matching bound that
+the solver limit does not cover. Results (``mces`` / ``computation_modes`` /
+``computation_times``) are written back into the batch, matching ``--hdf5_mode``.
+
+Distance modes: 1 = exact (<= ceiling); 2/4 = bound (>= ceiling); 9 = wall-capped
+(treated as >= ceiling, flagged); dist < 0 = per-pair error. A capped or errored
+pair never becomes a false "near", since it is excluded from the near pairs.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import h5py
+import numpy as np
+from joblib import Parallel, delayed
+from myopic_mces.myopic_mces import MCES
+from rdkit import RDLogger
+
+from mces_split.io import time_limit
+
+RDLogger.DisableLog("rdApp.*")
+
+CAPPED_MODE = 9
+
+
+def _run_pair(rid: int, smiles1: str, smiles2: str, threshold: float, solver: str,
+              solver_options: dict, wall_cap: float | None) -> tuple:
+    """Compute one pair under a hard wall-clock cap; cap hit -> ceiling, mode 9."""
+    t0 = time.time()
+    try:
+        with time_limit(wall_cap):
+            return MCES(smiles1, smiles2, threshold, rid, solver, solver_options,
+                        always_stronger_bound=False, catch_errors=True)
+    except TimeoutError:
+        return (rid, float(threshold), time.time() - t0, CAPPED_MODE)
+
+
+class BatchComputer:
+    """Computes a candidate-pair batch with myopic-MCES under solver + wall caps."""
+
+    def __init__(self, threshold: float = 10.0, solver: str = "PULP_CBC_CMD",
+                 solver_time_limit: float | None = 30.0, wall_cap: float | None = 45.0, n_jobs: int = -1):
+        self.threshold = threshold
+        self.solver = solver
+        self.solver_time_limit = solver_time_limit
+        self.wall_cap = wall_cap
+        self.n_jobs = n_jobs
+
+    def compute(self, batch_path: Path) -> None:
+        """Compute every pair in ``batch_path`` and write the results back in place."""
+        with h5py.File(batch_path, "r") as f:
+            idx = f["computation_indices"][:]
+            smiles = [s.decode() if isinstance(s, bytes) else str(s) for s in np.asarray(f["smiles"])]
+
+        options = dict(msg=False, threads=1)  # single-threaded solver under joblib parallelism
+        if self.solver_time_limit:
+            options["timeLimit"] = self.solver_time_limit
+        results = Parallel(n_jobs=self.n_jobs, batch_size=32, pre_dispatch="10*n_jobs")(
+            delayed(_run_pair)(int(rid), smiles[i1], smiles[i2], self.threshold, self.solver, options, self.wall_cap)
+            for rid, i1, i2 in idx
+        )
+        dist = np.array([r[1] for r in results], dtype=float)
+        times = np.array([r[2] for r in results], dtype=float)
+        modes = np.array([r[3] for r in results], dtype="uint8")
+
+        with h5py.File(batch_path, "a") as f:
+            for key, data, kw in (("mces", dist, {}), ("computation_times", times, {}),
+                                  ("computation_modes", modes, dict(dtype="uint8"))):
+                if key in f:
+                    del f[key]
+                f.create_dataset(key, data=data, compression="gzip", **kw)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=Path, required=True, help="HDF5 batch to compute in place")
+    parser.add_argument("--threshold", type=float, default=10.0, help="MCES ceiling")
+    parser.add_argument("--solver", default="PULP_CBC_CMD", help="PuLP solver (CPLEX_CMD if available)")
+    parser.add_argument("--solver-time-limit", type=float, default=30.0, help="per-pair ILP cap (s; 0 disables)")
+    parser.add_argument("--wall-cap", type=float, default=45.0, help="hard per-pair wall cap (s; 0 disables)")
+    parser.add_argument("--num-jobs", type=int, default=-1, help="parallel workers (-1 = all cores)")
+    args = parser.parse_args()
+    BatchComputer(args.threshold, args.solver, args.solver_time_limit or None,
+                  args.wall_cap or None, args.num_jobs).compute(args.batch)
+
+
+if __name__ == "__main__":
+    main()

--- a/spectus/mces_split/dataset.py
+++ b/spectus/mces_split/dataset.py
@@ -1,0 +1,91 @@
+"""The NIST train/val/test molecule folds, canonicalised to match SpecTUS.
+
+Molecule identity uses the same canonicalisation as SpecTUS's data-loading path
+(``utils.spectra_process_utils.remove_stereochemistry_and_canonicalize``): strip
+stereochemistry, then canonical SMILES. On the stereo-free NIST ``.smi`` files
+this is a no-op (verified byte-identical), but it pins our molecule set, dedup,
+and leakage check to SpecTUS's by construction.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+from rdkit import Chem, RDLogger
+
+RDLogger.DisableLog("rdApp.*")
+
+
+def canonicalize(smiles: str) -> str | None:
+    """SpecTUS-consistent canonical SMILES (stereo removed); None if unparseable."""
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    Chem.RemoveStereochemistry(mol)
+    return Chem.MolToSmiles(mol)
+
+
+def _load_unique(path: Path, limit: int | None) -> tuple[list[str], int]:
+    seen: dict[str, None] = {}
+    n_invalid = 0
+    with open(path) as f:
+        for line in f:
+            smiles = line.strip()
+            if not smiles:
+                continue
+            canon = canonicalize(smiles)
+            if canon is None:
+                n_invalid += 1
+                continue
+            seen.setdefault(canon, None)
+            if limit is not None and len(seen) >= limit:
+                break
+    return list(seen), n_invalid
+
+
+@dataclass
+class Folds:
+    """Unique canonical molecules per fold, plus the query universe (valid+test)."""
+
+    train: list[str]
+    valid: list[str]
+    test: list[str]
+    unparseable: dict[str, int]
+
+    @classmethod
+    def load(cls, data_dir: Path, limit_train: int | None = None, limit_queries: int | None = None) -> Folds:
+        """
+        Load and canonicalise train/valid/test ``.smi`` files.
+
+        Args:
+            data_dir (Path): directory with train.smi, valid.smi, test.smi.
+            limit_train (int | None): cap unique train molecules (testing).
+            limit_queries (int | None): cap unique molecules per query fold (testing).
+        Returns:
+            Folds: the loaded, de-duplicated folds.
+        """
+        train, inv_train = _load_unique(data_dir / "train.smi", limit_train)
+        valid, inv_valid = _load_unique(data_dir / "valid.smi", limit_queries)
+        test, inv_test = _load_unique(data_dir / "test.smi", limit_queries)
+        return cls(train, valid, test, dict(train=inv_train, valid=inv_valid, test=inv_test))
+
+    @property
+    def n_train(self) -> int:
+        return len(self.train)
+
+    def queries(self) -> pd.DataFrame:
+        """
+        One row per unique query molecule.
+
+        Returns:
+            pd.DataFrame: columns ``smiles``, ``in_valid``, ``in_test``, ``status``
+            (``exact_match`` for a training duplicate, else ``candidates``).
+        """
+        in_valid, in_test, train = set(self.valid), set(self.test), set(self.train)
+        rows = [
+            dict(smiles=s, in_valid=s in in_valid, in_test=s in in_test,
+                 status="exact_match" if s in train else "candidates")
+            for s in dict.fromkeys(self.valid + self.test)
+        ]
+        return pd.DataFrame(rows)

--- a/spectus/mces_split/io.py
+++ b/spectus/mces_split/io.py
@@ -1,0 +1,144 @@
+"""Shared I/O for the MCES-distance split: HDF5 batch read/write and the per-pair
+time cap.
+
+Batches use the ``myopic_mces`` ``--hdf5_mode`` layout: a ``computation_indices``
+array of ``(id, query_idx, train_idx)`` rows plus a ``smiles`` array they index
+into. Stage 2 adds ``mces`` (distance) and ``computation_modes`` to each batch.
+"""
+from __future__ import annotations
+
+import signal
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+NEAR_SCHEMA = pa.schema([("query", pa.string()), ("train", pa.string()), ("dist", pa.float64())])
+
+
+def decode_smiles(arr) -> np.ndarray:
+    """Decode an h5py SMILES array (variable-length bytes) to an object array of str."""
+    return np.array([s.decode() if isinstance(s, bytes) else str(s) for s in arr], dtype=object)
+
+
+def read_smiles(path: Path) -> np.ndarray:
+    """Read the (decoded) SMILES array from a batch — identical across all batches."""
+    with h5py.File(path, "r") as f:
+        return decode_smiles(np.asarray(f["smiles"]))
+
+
+def read_computed(path: Path) -> pd.DataFrame:
+    """
+    Read a computed batch into a (query, train, dist, mode) frame.
+
+    Args:
+        path (Path): batch HDF5 file that already carries the ``mces`` dataset.
+    Returns:
+        pd.DataFrame: one row per computed pair.
+    """
+    with h5py.File(path, "r") as f:
+        if "mces" not in f:
+            raise ValueError(f"{path} has no 'mces' dataset — run the compute stage on it first")
+        idx = f["computation_indices"][:]
+        smiles = decode_smiles(np.asarray(f["smiles"]))
+        dist = np.asarray(f["mces"], dtype=float)
+        mode = np.asarray(f["computation_modes"], dtype=int)
+    return pd.DataFrame(dict(query=smiles[idx[:, 1]], train=smiles[idx[:, 2]], dist=dist, mode=mode))
+
+
+def scan_error_query_smiles(batches_dir: Path) -> set[str]:
+    """
+    Distinct query SMILES that have at least one failed (dist<0) pair.
+
+    These queries have an uncomputable distance (a blind spot), so their
+    far/close status is unknowable at any threshold. Reads ``computation_indices``
+    contiguously then indexes it — h5py fancy-indexing on gzip is very slow.
+
+    Args:
+        batches_dir (Path): directory of computed batch HDF5 files.
+    Returns:
+        set[str]: query SMILES with a blind spot.
+    """
+    paths = sorted(batches_dir.glob("batch*.hdf5"))
+    smiles = read_smiles(paths[0])  # identical across batches
+    bad: set[str] = set()
+    for path in paths:
+        with h5py.File(path, "r") as f:
+            e = np.where(np.asarray(f["mces"]) < 0)[0]
+            if len(e) == 0:
+                continue
+            idx = np.asarray(f["computation_indices"])[e]
+        bad.update(smiles[idx[:, 1]])
+    return bad
+
+
+class BatchWriter:
+    """Streams ``(id, query_idx, train_idx)`` rows into fixed-size HDF5 batches."""
+
+    def __init__(self, out_dir: Path, smiles: list[str], batch_size: int, settings: dict):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self.out_dir = out_dir
+        self.smiles = smiles
+        self.batch_size = batch_size
+        self.settings = settings
+        self._buffer: list[np.ndarray] = []  # pending [k, 2] (query_idx, train_idx) blocks
+        self._pending = 0
+        self._next_id = 0
+        self.n_batches = 0
+
+    def add(self, query_idx: np.ndarray, train_idx: np.ndarray) -> None:
+        """Queue candidate pairs, flushing whole batches as they fill."""
+        self._buffer.append(np.column_stack([query_idx, train_idx]))
+        self._pending += len(query_idx)
+        while self._pending >= self.batch_size:
+            self._flush(self.batch_size)
+
+    def close(self) -> int:
+        """Flush the remainder and return the number of batches written."""
+        if self._pending:
+            self._flush(self._pending)
+        return self.n_batches
+
+    def _flush(self, n: int) -> None:
+        pairs = np.concatenate(self._buffer) if len(self._buffer) > 1 else self._buffer[0]
+        take, rest = pairs[:n], pairs[n:]
+        ids = np.arange(self._next_id, self._next_id + len(take))
+        indices = np.column_stack([ids, take]).astype("int64")
+        with h5py.File(self.out_dir / f"batch{self.n_batches}.hdf5", "w") as f:
+            f.create_dataset("computation_indices", data=indices, dtype="int64", compression="gzip")
+            f.create_dataset("smiles", data=self.smiles)
+            group = f.create_group("settings")
+            for key, value in self.settings.items():
+                group[key] = value
+        self._next_id += len(take)
+        self.n_batches += 1
+        self._buffer = [rest] if len(rest) else []
+        self._pending = len(rest)
+
+
+@contextmanager
+def time_limit(seconds: float | None) -> Iterator[None]:
+    """
+    Raise ``TimeoutError`` if the wrapped block runs longer than ``seconds``.
+
+    Bounds a single MCES pair: some pairs spend minutes in the (pure-Python)
+    matching bound, which the solver's own time limit does not cover. ``None`` or
+    0 disables the cap. Main-thread only (SIGALRM).
+    """
+    if not seconds:
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise TimeoutError(f"exceeded {seconds}s")
+
+    signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)

--- a/spectus/mces_split/prefilter.py
+++ b/spectus/mces_split/prefilter.py
@@ -1,0 +1,109 @@
+"""Stage 1: screen every query against train with the rigorous bounds and emit
+only the surviving candidate pairs as myopic-MCES HDF5 batches.
+
+For each of the ~48k query (valid+test) molecules we want its minimum MCES
+distance to ~195k train molecules -- ~9.5B pairs if done naively. The composite
+bound discards the ~99% that are provably >= the ceiling at numpy speed; only the
+structurally similar survivors are written out for the expensive ILP.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+from rdkit import Chem
+from tqdm import tqdm
+
+from mces_split.bounds import BondTypeBound, CompositeBound, Filter1Bound
+from mces_split.dataset import Folds
+from mces_split.io import BatchWriter
+
+
+class PreFilter:
+    """Screens query x train pairs with a composite lower bound into HDF5 batches."""
+
+    def __init__(self, bound: CompositeBound | None = None, ceiling: float = 10.0,
+                 batch_size: int = 10_000_000, query_chunk: int = 512, seed: int = 0):
+        self.bound = bound or CompositeBound([Filter1Bound(), BondTypeBound()])
+        self.ceiling = ceiling
+        self.batch_size = batch_size
+        self.query_chunk = query_chunk
+        self.seed = seed
+
+    def run(self, folds: Folds, out_dir: Path) -> dict:
+        """
+        Screen the folds and write candidate batches + queries.parquet + manifest.json.
+
+        Args:
+            folds (Folds): the loaded train/valid/test molecules.
+            out_dir (Path): output directory.
+        Returns:
+            dict: the manifest.
+        """
+        queries = folds.queries()
+        candidates = list(queries.loc[queries["status"] == "candidates", "smiles"])
+        smiles = folds.train + candidates  # global array; train first, then candidate queries
+        n_train = folds.n_train
+        mols = [Chem.MolFromSmiles(s) for s in smiles]
+
+        feats = self.bound.feature_matrices(mols)  # one matrix per bound, over all molecules
+        train_feats = [f[:n_train] for f in feats]
+        query_feats = [f[n_train:] for f in feats]
+
+        settings = dict(threshold=float(self.ceiling), choose_bound_dynamically=True)
+        writer = BatchWriter(out_dir / "batches", smiles, self.batch_size, settings)
+        has_candidate = np.zeros(len(candidates), dtype=bool)
+        order = np.random.default_rng(self.seed).permutation(len(candidates))  # mix across batches
+        n_pairs = 0
+        for start in tqdm(range(0, len(order), self.query_chunk), desc="prefilter", unit="chunk"):
+            block = order[start : start + self.query_chunk]
+            mask = self.bound.candidate_mask([f[block] for f in query_feats], train_feats, self.ceiling)
+            qi, ti = np.nonzero(mask)
+            if len(qi) == 0:
+                continue
+            has_candidate[block[qi]] = True
+            writer.add(block[qi] + n_train, ti)
+            n_pairs += len(qi)
+        n_batches = writer.close()
+
+        # A candidate query with zero surviving pairs is provably far (no MCES needed).
+        status = {candidates[i]: ("candidates" if has_candidate[i] else "no_candidates")
+                  for i in range(len(candidates))}
+        queries["status"] = queries.apply(lambda r: status.get(r["smiles"], r["status"]), axis=1)
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        queries.to_parquet(out_dir / "queries.parquet")
+        manifest = dict(
+            ceiling=self.ceiling, n_train=n_train, n_valid_unique=len(folds.valid),
+            n_test_unique=len(folds.test), n_query_unique=len(queries),
+            n_candidate_pairs=int(n_pairs), n_batches=n_batches, batch_size=self.batch_size,
+            status_counts=queries["status"].value_counts().to_dict(), unparseable=folds.unparseable,
+        )
+        (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+        print(f"candidate pairs: {n_pairs:,} in {n_batches} batches; status: {manifest['status_counts']}")
+        return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, default=Path("data/nist"), help="dir with {train,valid,test}.smi")
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--ceiling", type=float, default=10.0, help="MCES distance threshold")
+    parser.add_argument("--batch-size", type=int, default=10_000_000, help="candidate pairs per HDF5 batch")
+    parser.add_argument("--query-chunk", type=int, default=512, help="queries per cdist block")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--limit-train", type=int, default=None, help="testing: cap train molecules")
+    parser.add_argument("--limit-queries", type=int, default=None, help="testing: cap queries per fold")
+    args = parser.parse_args()
+
+    folds = Folds.load(args.data_dir, args.limit_train, args.limit_queries)
+    print(f"unique canonical: train={folds.n_train} valid={len(folds.valid)} test={len(folds.test)} "
+          f"(unparseable: {folds.unparseable})")
+    PreFilter(ceiling=args.ceiling, batch_size=args.batch_size,
+              query_chunk=args.query_chunk, seed=args.seed).run(folds, args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/spectus/mces_split/split.py
+++ b/spectus/mces_split/split.py
@@ -1,0 +1,127 @@
+"""Stage 3: derive the far/close split from the computed batches.
+
+First streams every exact near pair (distance < ceiling) into ``near_pairs.parquet``
+(bounded memory; skipped if it already exists). From that single file the split
+can be reported at any threshold <= ceiling with no MCES recompute -- optionally
+excluding molecules with an incomputable pair, which removes every blind spot so
+the far set is certain at all thresholds at once.
+
+A query is *far* at threshold T when its nearest train neighbour is at distance
+>= T (matching MassSpecGym's single-linkage criterion). Only exact (mode-1) pairs
+below the ceiling can make a query close; errors and wall-caps are excluded.
+
+Outputs (in ``--results-dir``): near_pairs.parquet, nn_distances.parquet (per
+query), incomputable.smi (if excluding), and far_{valid,test}_t{T}[_clean].smi.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from mces_split.io import NEAR_SCHEMA, read_computed, scan_error_query_smiles
+
+
+class SplitReport:
+    """Builds the near-pairs file and reports the far/close split at any threshold."""
+
+    def __init__(self, out_dir: Path, results_dir: Path):
+        self.out_dir = out_dir
+        self.results_dir = results_dir
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self.ceiling = json.loads((out_dir / "manifest.json").read_text())["ceiling"]
+        self.queries = pd.read_parquet(out_dir / "queries.parquet")
+        self.near_path = results_dir / "near_pairs.parquet"
+
+    def build_near_pairs(self) -> None:
+        """Stream exact near pairs (< ceiling) from all batches into near_pairs.parquet."""
+        if self.near_path.exists():
+            print(f"using existing {self.near_path.name} (skipping batch streaming)")
+            return
+        writer = pq.ParquetWriter(self.near_path, NEAR_SCHEMA)
+        n_pairs = n_err = n_capped = n_near = 0
+        try:
+            for path in sorted((self.out_dir / "batches").glob("batch*.hdf5")):
+                df = read_computed(path)
+                n_pairs += len(df)
+                n_err += int((df["dist"] < 0).sum())
+                n_capped += int((df["mode"] == 9).sum())
+                near = df[(df["mode"] == 1) & (df["dist"] >= 0) & (df["dist"] < self.ceiling)]
+                if not near.empty:
+                    n_near += len(near)
+                    writer.write_table(pa.Table.from_pandas(near[["query", "train", "dist"]],
+                                                            schema=NEAR_SCHEMA, preserve_index=False))
+        finally:
+            writer.close()
+        print(f"computed pairs: {n_pairs:,}  near(<{self.ceiling}): {n_near:,}  "
+              f"errors: {n_err}  wall-capped: {n_capped}")
+
+    def _annotate(self, exclude_incomputable: bool) -> pd.DataFrame:
+        """Per-query table with nearest distance, witness, and (optionally) incomputable flag."""
+        near = pd.read_parquet(self.near_path)
+        nearest = near.loc[near.groupby("query")["dist"].idxmin()].set_index("query")
+        q = self.queries.copy()
+        q["nearest"] = q["smiles"].map(nearest["dist"])
+        q["witness"] = q["smiles"].map(nearest["train"])
+        q.loc[q["status"] == "exact_match", "nearest"] = 0.0
+        if exclude_incomputable:
+            bad = scan_error_query_smiles(self.out_dir / "batches")
+            q["incomputable"] = q["smiles"].isin(bad)
+            (self.results_dir / "incomputable.smi").write_text("\n".join(q.loc[q["incomputable"], "smiles"]) + "\n")
+        return q
+
+    def report(self, thresholds: list[float], exclude_incomputable: bool = False) -> pd.DataFrame:
+        """
+        Write the far sets and per-query table; print and return a summary.
+
+        Args:
+            thresholds (list[float]): thresholds to slice at (each <= ceiling).
+            exclude_incomputable (bool): drop molecules with any failed pair.
+        Returns:
+            pd.DataFrame: rows of (threshold, far_valid, far_test, n_valid, n_test).
+        """
+        q = self._annotate(exclude_incomputable)
+        q.to_parquet(self.results_dir / "nn_distances.parquet")
+        usable = q[~q.get("incomputable", False)] if exclude_incomputable else q
+        n_valid, n_test = int(usable["in_valid"].sum()), int(usable["in_test"].sum())
+        suffix = "_clean" if exclude_incomputable else ""
+        if exclude_incomputable:
+            print(f"incomputable excluded: valid {int((q['in_valid'] & q['incomputable']).sum())}, "
+                  f"test {int((q['in_test'] & q['incomputable']).sum())} (of {int(q['incomputable'].sum())})")
+        print(f"clean universe: valid {n_valid}, test {n_test} (ceiling {self.ceiling})")
+
+        rows = []
+        for t in sorted(thresholds):
+            if t > self.ceiling:
+                print(f"  t={t}: skipped (> computed ceiling {self.ceiling})")
+                continue
+            is_far = ~(usable["nearest"] < t)  # NaN (no near neighbour) -> far
+            fv = usable.loc[usable["in_valid"] & is_far, "smiles"]
+            ft = usable.loc[usable["in_test"] & is_far, "smiles"]
+            (self.results_dir / f"far_valid_t{int(t)}{suffix}.smi").write_text("\n".join(fv) + "\n")
+            (self.results_dir / f"far_test_t{int(t)}{suffix}.smi").write_text("\n".join(ft) + "\n")
+            print(f"  far >= {t:>2}: valid {len(fv):>6} ({100 * len(fv) / n_valid:5.2f}%)  "
+                  f"test {len(ft):>6} ({100 * len(ft) / n_test:5.2f}%)")
+            rows.append(dict(threshold=t, far_valid=len(fv), far_test=len(ft), n_valid=n_valid, n_test=n_test))
+        return pd.DataFrame(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, required=True, help="stage-1 dir (batches/, queries.parquet, manifest.json)")
+    parser.add_argument("--results-dir", type=Path, required=True, help="where to write near pairs and far sets")
+    parser.add_argument("--thresholds", type=float, nargs="+", default=[10.0], help="thresholds to slice at (<= ceiling)")
+    parser.add_argument("--exclude-incomputable", action="store_true",
+                        help="drop molecules with any failed pair -> far set certain at all thresholds")
+    args = parser.parse_args()
+    report = SplitReport(args.out_dir, args.results_dir)
+    report.build_near_pairs()
+    report.report(args.thresholds, args.exclude_incomputable)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mces_split.py
+++ b/tests/test_mces_split.py
@@ -1,0 +1,47 @@
+"""End-to-end check: the pipeline's far/close split must match a brute-force
+minimum MCES over all training molecules (the rigour guarantee, in miniature)."""
+from __future__ import annotations
+
+from myopic_mces.myopic_mces import MCES
+
+from mces_split import BatchComputer, Folds, PreFilter, SplitReport
+
+TRAIN = ["CCO", "CCN", "CCC", "CCCC", "CCCCC", "CCCCCC", "c1ccccc1", "c1ccncc1",
+         "CC(=O)O", "CCOCC", "CC(C)O", "CCCCO"]
+VALID = ["CCCCCO", "c1ccccc1C"]                       # near a train molecule
+TEST = ["CCCCCCCCCCCCCCCCCCCC", "O=S(=O)(O)c1ccc(N)cc1"]  # the C20 alkane is far from all
+CEILING = 10.0
+
+
+def _brute_force_far(query: str, train: list[str]) -> bool:
+    """A query is far iff no training molecule is at exact MCES distance < ceiling."""
+    options = dict(msg=False, threads=1)
+    for t in train:
+        _, dist, _, mode = MCES(query, t, CEILING, 0, "PULP_CBC_CMD", options, always_stronger_bound=False)
+        if mode == 1 and 0 <= dist < CEILING:
+            return False
+    return True
+
+
+def test_far_split_matches_bruteforce(tmp_path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "train.smi").write_text("\n".join(TRAIN) + "\n")
+    (data / "valid.smi").write_text("\n".join(VALID) + "\n")
+    (data / "test.smi").write_text("\n".join(TEST) + "\n")
+    out, results = tmp_path / "run", tmp_path / "results"
+
+    folds = Folds.load(data)
+    PreFilter(ceiling=CEILING, batch_size=10_000).run(folds, out)
+    for batch in sorted((out / "batches").glob("batch*.hdf5")):
+        BatchComputer(threshold=CEILING, n_jobs=1).compute(batch)
+    report = SplitReport(out, results)
+    report.build_near_pairs()
+    report.report([CEILING])
+
+    pipeline_far = set((results / "far_valid_t10.smi").read_text().split())
+    pipeline_far |= set((results / "far_test_t10.smi").read_text().split())
+
+    for query in dict.fromkeys(folds.valid + folds.test):
+        assert (query in pipeline_far) == _brute_force_far(query, folds.train), query
+    assert pipeline_far, "expected at least one far molecule (the C20 alkane)"


### PR DESCRIPTION
## Summary

Adds an analysis (`spectus/mces_split/`) that identifies **validation/test molecules whose nearest training-set neighbour is at MCES distance ≥ T** (default 10), showing the NIST train/val/test split (built on InChIKey14) contains structurally novel molecules — not just near-duplicates of training compounds. Distance 10 matches the MCES-based split criterion used in MassSpecGym; the metric is the myopic maximum-common-edge-subgraph distance from [`myopic-mces`](https://github.com/AlBi-HHU/myopic-mces).

## Result (NIST)

Molecules ≥ T MCES edits from *every* training molecule, over the clean universe (molecules where every distance is computable):

| T | far_valid | far_test |
|---|-----------|----------|
| 6 | 2,164 (8.96%) | 2,170 (8.98%) |
| 8 | 1,005 (4.16%) | 1,002 (4.15%) |
| 10 | 446 (1.85%) | 469 (1.94%) |

357 molecules (0.7%) are excluded as MCES-intractable (very large structures where the ILP cannot terminate); 0 false positives among all computable pairs. So ~98% of val/test molecules have a train neighbour within <10 MCES, and ~2% are genuinely far.

## How

- Two **vectorised, rigorous MCES lower bounds** (filter1 degree + bond-type) prune ~99% of the ~9.5 B query×train pairs at numpy speed — a discarded pair is *provably* ≥ ceiling, so no false "far".
- Survivors are computed with myopic-MCES (dynamic bound, per-pair solver + wall caps).
- `SplitReport` derives the far/close split at any threshold ≤ ceiling from `near_pairs.parquet`, optionally excluding incomputable molecules so the set is certain at every threshold.

## Scope & reproducibility

- Optional `[mces]` extra only — **no torch is pulled into core deps** (regular SpecTUS users are unaffected). Pinned to the versions that produced the result.
- MetaCentrum PBS runners (`config_runners/run_mces_split*.sh`) + a one-shot driver; the compute array is idempotent/resumable.
- `pytest tests/test_mces_split.py` runs the whole pipeline on a tiny fixture and checks far-classification against a brute-force minimum.

See `spectus/mces_split/README.md` for the architecture and workflow.
